### PR TITLE
Выброс ошибки в API методах, если метод не привязан к навыку

### DIFF
--- a/aliceio/exceptions.py
+++ b/aliceio/exceptions.py
@@ -76,3 +76,14 @@ class ClientDecodeError(AliceioError):
             f"{original_type.__module__}.{original_type.__name__}: {self.original}\n"
             f"Content: {self.data}"
         )
+
+
+class MethodNotMountedToSkillError(DetailedAliceioError):
+    def __init__(self) -> None:
+        super().__init__(
+            message="This method is not mounted to a any skill instance, "
+            "please call it explicilty "
+            "with skill instance `await skill(method)`\n"
+            "or mount method to a skill instance `method.as_(skill)` "
+            "and then call it `await method()`",
+        )

--- a/aliceio/methods/images/delete_image.py
+++ b/aliceio/methods/images/delete_image.py
@@ -1,12 +1,10 @@
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from aliceio.client.alice import AliceAPIServer
 from aliceio.enums import FileType, HttpMethod
+from aliceio.exceptions import MethodNotMountedToSkillError
 from aliceio.methods.base import AliceMethod
 from aliceio.types import Result
-
-if TYPE_CHECKING:
-    from aliceio.client.skill import Skill
 
 
 class DeleteImage(AliceMethod[Result]):
@@ -29,9 +27,10 @@ class DeleteImage(AliceMethod[Result]):
             )
 
     def api_url(self, api_server: AliceAPIServer) -> str:
-        skill: Skill = cast("Skill", self.skill)
+        if self.skill is None:
+            raise MethodNotMountedToSkillError
         return api_server.delete_file_url(
-            skill_id=skill.id,
+            skill_id=self.skill.id,
             file_type=FileType.IMAGES,
             file_id=self.file_id,
         )

--- a/aliceio/methods/images/get_images.py
+++ b/aliceio/methods/images/get_images.py
@@ -1,12 +1,8 @@
-from typing import TYPE_CHECKING, cast
-
 from aliceio.client.alice import AliceAPIServer
 from aliceio.enums import FileType, HttpMethod
+from aliceio.exceptions import MethodNotMountedToSkillError
 from aliceio.methods.base import AliceMethod
 from aliceio.types import UploadedImagesList
-
-if TYPE_CHECKING:
-    from aliceio.client.skill import Skill
 
 
 class GetImages(AliceMethod[UploadedImagesList]):
@@ -14,8 +10,9 @@ class GetImages(AliceMethod[UploadedImagesList]):
     __http_method__ = HttpMethod.GET
 
     def api_url(self, api_server: AliceAPIServer) -> str:
-        skill: Skill = cast("Skill", self.skill)
+        if self.skill is None:
+            raise MethodNotMountedToSkillError
         return api_server.get_all_files_url(
-            skill_id=skill.id,
+            skill_id=self.skill.id,
             file_type=FileType.IMAGES,
         )

--- a/aliceio/methods/images/upload_image.py
+++ b/aliceio/methods/images/upload_image.py
@@ -1,13 +1,10 @@
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional
 
 from aliceio.client.alice import AliceAPIServer
 from aliceio.enums import FileType, HttpMethod
-from aliceio.exceptions import AliceWrongFieldError
+from aliceio.exceptions import AliceWrongFieldError, MethodNotMountedToSkillError
 from aliceio.methods.base import AliceMethod
 from aliceio.types import InputFile, PreUploadedImage
-
-if TYPE_CHECKING:
-    from aliceio.client.skill import Skill
 
 
 class UploadImage(AliceMethod[PreUploadedImage]):
@@ -41,8 +38,9 @@ class UploadImage(AliceMethod[PreUploadedImage]):
             raise AliceWrongFieldError('"file" and "url" cannot be specified together')
 
     def api_url(self, api_server: AliceAPIServer) -> str:
-        skill: Skill = cast("Skill", self.skill)
+        if self.skill is None:
+            raise MethodNotMountedToSkillError
         return api_server.upload_file_url(
-            skill_id=skill.id,
+            skill_id=self.skill.id,
             file_type=FileType.IMAGES,
         )

--- a/aliceio/methods/sounds/delete_sound.py
+++ b/aliceio/methods/sounds/delete_sound.py
@@ -1,12 +1,10 @@
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from aliceio.client.alice import AliceAPIServer
 from aliceio.enums import FileType, HttpMethod
+from aliceio.exceptions import MethodNotMountedToSkillError
 from aliceio.methods.base import AliceMethod
 from aliceio.types import Result
-
-if TYPE_CHECKING:
-    from aliceio.client.skill import Skill
 
 
 class DeleteSound(AliceMethod[Result]):
@@ -29,9 +27,10 @@ class DeleteSound(AliceMethod[Result]):
             )
 
     def api_url(self, api_server: AliceAPIServer) -> str:
-        skill: Skill = cast("Skill", self.skill)
+        if self.skill is None:
+            raise MethodNotMountedToSkillError
         return api_server.delete_file_url(
-            skill_id=skill.id,
+            skill_id=self.skill.id,
             file_type=FileType.SOUNDS,
             file_id=self.file_id,
         )

--- a/aliceio/methods/sounds/get_sounds.py
+++ b/aliceio/methods/sounds/get_sounds.py
@@ -1,12 +1,8 @@
-from typing import TYPE_CHECKING, cast
-
 from aliceio.client.alice import AliceAPIServer
 from aliceio.enums import FileType, HttpMethod
+from aliceio.exceptions import MethodNotMountedToSkillError
 from aliceio.methods.base import AliceMethod
 from aliceio.types import UploadedSoundsList
-
-if TYPE_CHECKING:
-    from aliceio.client.skill import Skill
 
 
 class GetSounds(AliceMethod[UploadedSoundsList]):
@@ -14,8 +10,9 @@ class GetSounds(AliceMethod[UploadedSoundsList]):
     __http_method__ = HttpMethod.GET
 
     def api_url(self, api_server: AliceAPIServer) -> str:
-        skill: Skill = cast("Skill", self.skill)
+        if self.skill is None:
+            raise MethodNotMountedToSkillError
         return api_server.get_all_files_url(
-            skill_id=skill.id,
+            skill_id=self.skill.id,
             file_type=FileType.SOUNDS,
         )

--- a/aliceio/methods/sounds/upload_sound.py
+++ b/aliceio/methods/sounds/upload_sound.py
@@ -1,12 +1,10 @@
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from aliceio.client.alice import AliceAPIServer
 from aliceio.enums import FileType, HttpMethod
+from aliceio.exceptions import MethodNotMountedToSkillError
 from aliceio.methods.base import AliceMethod
 from aliceio.types import InputFile, PreUploadedSound
-
-if TYPE_CHECKING:
-    from aliceio.client.skill import Skill
 
 
 class UploadSound(AliceMethod[PreUploadedSound]):
@@ -29,8 +27,9 @@ class UploadSound(AliceMethod[PreUploadedSound]):
             )
 
     def api_url(self, api_server: AliceAPIServer) -> str:
-        skill: Skill = cast("Skill", self.skill)
+        if self.skill is None:
+            raise MethodNotMountedToSkillError
         return api_server.upload_file_url(
-            skill_id=skill.id,
+            skill_id=self.skill.id,
             file_type=FileType.SOUNDS,
         )

--- a/tests/test_methods/test_base.py
+++ b/tests/test_methods/test_base.py
@@ -4,6 +4,7 @@ import pytest
 
 from aliceio.client.alice import AliceAPIServer
 from aliceio.enums import HttpMethod
+from aliceio.exceptions import MethodNotMountedToSkillError
 from aliceio.methods.base import AliceMethod
 from tests.mocked import MockedSkill
 
@@ -37,7 +38,7 @@ class TestAliceMethod:
 
     async def test_await_without_skill(self, skill: MockedSkill):
         method = MyMethod()
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MethodNotMountedToSkillError):
             await method
 
     async def test_skill_call(self, skill: MockedSkill):

--- a/tests/test_methods/test_images.py
+++ b/tests/test_methods/test_images.py
@@ -1,7 +1,7 @@
 import pytest
 
 from aliceio.client.alice import PRODUCTION
-from aliceio.exceptions import AliceWrongFieldError
+from aliceio.exceptions import AliceWrongFieldError, MethodNotMountedToSkillError
 from aliceio.methods import DeleteImage, GetImages, UploadImage
 from aliceio.types import BufferedInputFile
 from tests.mocked import MockedSkill
@@ -11,7 +11,7 @@ class TestUploadImage:
     def test_api_url(self, skill: MockedSkill):
         method = UploadImage(file=BufferedInputFile(file=b""))
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(MethodNotMountedToSkillError):
             method.api_url(PRODUCTION)
 
         method.as_(skill)
@@ -32,7 +32,7 @@ class TestGetImages:
     def test_api_url(self, skill: MockedSkill):
         method = GetImages(file=BufferedInputFile(file=b""))
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(MethodNotMountedToSkillError):
             method.api_url(PRODUCTION)
 
         method.as_(skill)
@@ -44,7 +44,7 @@ class TestDeleteImage:
     def test_api_url(self, skill: MockedSkill):
         method = DeleteImage(file_id="FILE_ID")
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(MethodNotMountedToSkillError):
             method.api_url(PRODUCTION)
 
         method.as_(skill)

--- a/tests/test_methods/test_sounds.py
+++ b/tests/test_methods/test_sounds.py
@@ -1,6 +1,7 @@
 import pytest
 
 from aliceio.client.alice import PRODUCTION
+from aliceio.exceptions import MethodNotMountedToSkillError
 from aliceio.methods import DeleteSound, GetSounds, UploadSound
 from aliceio.types import BufferedInputFile
 from tests.mocked import MockedSkill
@@ -10,7 +11,7 @@ class TestUploadImage:
     def test_api_url(self, skill: MockedSkill):
         method = UploadSound(file=BufferedInputFile(file=b""))
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(MethodNotMountedToSkillError):
             method.api_url(PRODUCTION)
 
         method.as_(skill)
@@ -22,7 +23,7 @@ class TestGetSounds:
     def test_api_url(self, skill: MockedSkill):
         method = GetSounds(file=BufferedInputFile(file=b""))
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(MethodNotMountedToSkillError):
             method.api_url(PRODUCTION)
 
         method.as_(skill)
@@ -34,7 +35,7 @@ class TestDeleteSound:
     def test_api_url(self, skill: MockedSkill):
         method = DeleteSound(file_id="FILE_ID")
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(MethodNotMountedToSkillError):
             method.api_url(PRODUCTION)
 
         method.as_(skill)


### PR DESCRIPTION
# Описание

Убрал ненужную (и к тому же ошибочную) привязку метода к навыку
Сделал выброс ошибки, если пытаться получить ссылку без привязанного навыка

## Тип изменения

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)