### PR TITLE
Поддержка рантайм контекста облачных яндекс функций

### DIFF
--- a/aliceio/webhook/yandex_functions/__init__.py
+++ b/aliceio/webhook/yandex_functions/__init__.py
@@ -1,7 +1,9 @@
 from .base import BaseYandexFunctionsRequestHandler
+from .context import RuntimeContext
 from .one_skill import OneSkillYandexFunctionsRequestHandler
 
 __all__ = (
     "BaseYandexFunctionsRequestHandler",
     "OneSkillYandexFunctionsRequestHandler",
+    "RuntimeContext",
 )

--- a/aliceio/webhook/yandex_functions/base.py
+++ b/aliceio/webhook/yandex_functions/base.py
@@ -7,12 +7,13 @@ from aliceio import Dispatcher, Skill
 from aliceio.types import Update
 from aliceio.types.base import AliceObject
 from aliceio.utils.funcs import prepare_value
-from aliceio.webhook.yandex_functions.context import RuntimeContext
+
+from .context import RuntimeContext
 
 _Event = dict[str, Any]
 _Response = Optional[dict[str, Any]]
 
-YСF_CONTEXT_KEY = "ycf_context"
+YCF_CONTEXT_KEY = "ycf_context"
 
 
 class BaseYandexFunctionsRequestHandler(ABC):
@@ -54,7 +55,7 @@ class BaseYandexFunctionsRequestHandler(ABC):
             skill,
             update,
             **self.data,
-            **{YСF_CONTEXT_KEY: context},
+            **{YCF_CONTEXT_KEY: context},
         )
         return self._build_response(result)
 

--- a/aliceio/webhook/yandex_functions/context.py
+++ b/aliceio/webhook/yandex_functions/context.py
@@ -1,0 +1,17 @@
+from typing import Optional, Protocol
+
+
+class RuntimeContext(Protocol):
+    function_name: str
+    function_version: str
+    function_folder_id: str
+    invoked_function_arn: str
+    memory_limit_in_mb: int
+    request_id: str
+    log_group_name: str
+    log_stream_name: str
+    deadline_ms: int
+    token: Optional[str]
+    aws_request_id: str
+
+    def get_remaining_time_in_millis(self) -> int: ...

--- a/aliceio/webhook/yandex_functions/one_skill.py
+++ b/aliceio/webhook/yandex_functions/one_skill.py
@@ -2,12 +2,9 @@ from typing import Any, Optional
 
 from aliceio import Dispatcher, Skill, loggers
 from aliceio.types import Update
-from aliceio.webhook.yandex_functions.base import (
-    BaseYandexFunctionsRequestHandler,
-    _Context,
-    _Event,
-    _Response,
-)
+
+from .base import BaseYandexFunctionsRequestHandler, _Event, _Response
+from .context import RuntimeContext
 
 
 class OneSkillYandexFunctionsRequestHandler(BaseYandexFunctionsRequestHandler):
@@ -26,14 +23,14 @@ class OneSkillYandexFunctionsRequestHandler(BaseYandexFunctionsRequestHandler):
         super().__init__(dispatcher=dispatcher, **data)
         self.skill = skill
 
-    async def resolve_skill(self, event: _Event, context: _Context) -> Skill:
+    async def resolve_skill(self, event: _Event, context: RuntimeContext) -> Skill:
         return self.skill
 
     async def _handle_request(
         self,
         skill: Skill,
         event: _Event,
-        context: _Context,
+        context: RuntimeContext,
         update: Optional[Update] = None,
     ) -> _Response:
         update = await self._validate_update(skill, event, context)

--- a/docs/tutorial/connect-yandex-functions.md
+++ b/docs/tutorial/connect-yandex-functions.md
@@ -52,21 +52,29 @@
 
     from aliceio import Dispatcher, Skill
     from aliceio.types import AliceResponse, Message, Response
-    from aliceio.webhook.yandex_functions import OneSkillYandexFunctionsRequestHandler
+    from aliceio.webhook.yandex_functions import (
+        OneSkillYandexFunctionsRequestHandler,
+        RuntimeContext,
+    )
 
     dp = Dispatcher()
     skill = Skill(skill_id="...")  # Вставьте айди навыка
     requests_handler = OneSkillYandexFunctionsRequestHandler(dp, skill)
 
-
     @dp.message()
-    async def message_handler(message: Message) -> AliceResponse:
+    async def message_handler(
+        message: Message,
+        ycf_context: RuntimeContext,
+    ) -> AliceResponse:
         text = "Привет!" if message.session.new else message.original_utterance
+        text += (
+            "\n\nПеред отправкой у меня осталось "
+            f"{ycf_context.get_remaining_time_in_millis()} миллисекунд"
+        )
         return AliceResponse(response=Response(text=text))
 
-
     # Нужно поставить эту функцию как точку входа
-    async def main(event: Any, context: Any) -> Any:
+    async def main(event: dict[str, Any], context: RuntimeContext) -> Any:
         return await requests_handler(event, context)
         # аналогично:
         # return await requests_handler.handle(event, context)
@@ -104,3 +112,10 @@
 Перейдите на вкладку **Тестирование** и проверьте работу вашего навыка:
 
 ![testing.png](../_static/testing.png)
+
+!!! info "Дополнительные возможности"
+    При использовании облачных функций Яндекса у вас появляется возможность
+    обратиться к контексту вызова по ключу `ycf_context` в мидлварях и хэндлерах.
+
+    https://yandex.cloud/ru/docs/functions/concepts/runtime/execution-context
+    https://yandex.cloud/ru/docs/functions/lang/python/context

--- a/examples/yandex_functions.py
+++ b/examples/yandex_functions.py
@@ -2,7 +2,10 @@ from typing import Any
 
 from aliceio import Dispatcher, Skill
 from aliceio.types import AliceResponse, Message, Response
-from aliceio.webhook.yandex_functions import OneSkillYandexFunctionsRequestHandler
+from aliceio.webhook.yandex_functions import (
+    OneSkillYandexFunctionsRequestHandler,
+    RuntimeContext,
+)
 
 dp = Dispatcher()
 skill = Skill(skill_id="...")  # Вставьте айди навыка
@@ -10,13 +13,20 @@ requests_handler = OneSkillYandexFunctionsRequestHandler(dp, skill)
 
 
 @dp.message()
-async def message_handler(message: Message) -> AliceResponse:
+async def message_handler(
+    message: Message,
+    ycf_context: RuntimeContext,
+) -> AliceResponse:
     text = "Привет!" if message.session.new else message.original_utterance
+    text += (
+        "\n\nПеред отправкой у меня осталось "
+        f"{ycf_context.get_remaining_time_in_millis()} миллисекунд"
+    )
     return AliceResponse(response=Response(text=text))
 
 
 # Нужно поставить эту функцию как точку входа
-async def main(event: Any, context: Any) -> Any:
+async def main(event: dict[str, Any], context: RuntimeContext) -> Any:
     return await requests_handler(event, context)
     # аналогично:
     # return await requests_handler.handle(event, context)

--- a/tests/test_webhook/test_yandex_functions.py
+++ b/tests/test_webhook/test_yandex_functions.py
@@ -9,8 +9,10 @@ from aliceio import Dispatcher, F
 from aliceio.enums import EventType
 from aliceio.types import AliceResponse, Message, Response, Session, Update, User
 from aliceio.types.alice_event import AliceEvent
-from aliceio.webhook.yandex_functions import OneSkillYandexFunctionsRequestHandler
-from aliceio.webhook.yandex_functions.context import RuntimeContext
+from aliceio.webhook.yandex_functions import (
+    OneSkillYandexFunctionsRequestHandler,
+    RuntimeContext,
+)
 from tests.mocked.mocked_skill import MockedSkill
 
 


### PR DESCRIPTION
# Описание

- Protocol для runtime.RuntimeContext из внутренней библиотеки ycf
- Передача контекста в контекстные данные мидлварей и хэндлеров
- Пример использования ycf_context и упоминание его в документации

## Тип изменения

- [x] Новый функционал (некритическое изменение, добавляющее функциональность)
- [x] Это изменение требует обновления документации.
