### PR TITLE
Поддержка интерфейса payment из meta.interfaces

### DIFF
--- a/aliceio/types/interfaces.py
+++ b/aliceio/types/interfaces.py
@@ -1,10 +1,19 @@
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Optional
+
+from typing_extensions import TypeAlias, TypedDict
 
 from aliceio.types.base import AliceObject
 
-AccountLinking = dict[str, Any]
-Screen = dict[str, Any]
-AudioPlayer = dict[str, Any]
+
+class _EmptyDict(TypedDict):
+    pass
+
+
+AccountLinking: TypeAlias = _EmptyDict
+Screen: TypeAlias = _EmptyDict
+AudioPlayer: TypeAlias = _EmptyDict
+Payments: TypeAlias = _EmptyDict
 
 
 class Interfaces(AliceObject):
@@ -17,6 +26,7 @@ class Interfaces(AliceObject):
     account_linking: Optional[AccountLinking] = None
     screen: Optional[Screen] = None
     audio_player: Optional[AudioPlayer] = None
+    payments: Optional[Payments] = None
 
     if TYPE_CHECKING:
 
@@ -26,11 +36,24 @@ class Interfaces(AliceObject):
             account_linking: Optional[AccountLinking] = None,
             screen: Optional[Screen] = None,
             audio_player: Optional[AudioPlayer] = None,
+            payments: Optional[Payments] = None,
             **__pydantic_kwargs: Any,
         ) -> None:
             super().__init__(
                 account_linking=account_linking,
                 screen=screen,
                 audio_player=audio_player,
+                payments=payments,
                 **__pydantic_kwargs,
             )
+
+    @cached_property
+    def available_interfaces(self) -> set[str]:
+        return {
+            interface
+            for interface in self.__annotations__
+            if isinstance(getattr(self, interface, None), dict)
+        }
+
+    def is_interface_available(self, interface: str) -> bool:
+        return interface in self.available_interfaces

--- a/tests/test_api/test_types/test_interfaces.py
+++ b/tests/test_api/test_types/test_interfaces.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+import pytest
+
+from aliceio.types import Interfaces
+
+
+class TestInterfaces:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"account_linking": {}},
+            {"screen": {}},
+            {"audio_player": {}},
+            {"payments": {}},
+            {"account_linking": {}, "screen": {}, "audio_player": {}, "payments": {}},
+        ],
+    )
+    def test_available_interfaces(self, kwargs: dict[str, Any]) -> None:
+        interfaces = Interfaces(**kwargs)
+        assert kwargs.keys() == interfaces.available_interfaces
+
+    def test_available_interfaces_incorrect_init(self) -> None:
+        interfaces = Interfaces(amongus="kindasus")
+        assert interfaces.available_interfaces == set()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"account_linking": {}},
+            {"screen": {}},
+            {"audio_player": {}},
+            {"payments": {}},
+            {"account_linking": {}, "screen": {}, "audio_player": {}, "payments": {}},
+        ],
+    )
+    def test_is_interface_available(self, kwargs: dict[str, Any]) -> None:
+        interfaces = Interfaces(**kwargs)
+
+        for interface in kwargs:
+            assert interfaces.is_interface_available(interface)
+
+    def test_is_intreface_available_incorrect_init(self) -> None:
+        interfaces = Interfaces(amongus="kindasus")
+
+        assert not interfaces.is_interface_available("amongus")


### PR DESCRIPTION
# Описание

Случайно заметил поле `payments` в `meta.interfaces` во время тестирования навыка, в доке его нет :(
Добавил это поле, улучшил типизацию модели Interfaces и добавил вспомогательные методы

```json
{
  "meta": {
    "interfaces": {
      "screen": {},
      "payments": {},
      "account_linking": {}
    }
  },
  "session": {},
  "request": {},
  "state": {},
  "version": "1.0"
}

```

## Тип изменения

Удалите неактуальные варианты.

- [x] Новый функционал (некритическое изменение, добавляющее функциональность)
